### PR TITLE
Add deprecation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
-browserslist-cli
-================
+# DEPREACTED: Use Browserslist built-in CLI instead
 
 Command line interface for [browserslist](https://github.com/ai/browserslist).
 


### PR DESCRIPTION
It is easy to miss npm deprecation warning. One more will be better.